### PR TITLE
More config in ssm param store

### DIFF
--- a/id-provider/lib/openID-stack.ts
+++ b/id-provider/lib/openID-stack.ts
@@ -85,14 +85,6 @@ export class OIDCProviderStack extends Stack {
         AppDeploymentPolicy: new PolicyDocument({
           assignSids: true,
           statements: [
-            // in trial without
-            // new PolicyStatement({
-            //   effect: Effect.ALLOW,
-            //   actions: ["sts:AssumeRole"],
-            //   resources: [
-            //     `arn:aws:iam::${this.account}:role/WebsiteDeployerRole`,
-            //   ],
-            // }),
             new PolicyStatement({
               effect: Effect.ALLOW,
               actions: ["cloudfront:CreateInvalidation"],


### PR DESCRIPTION
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: try to checkout boomtap-feed in the process
- ci: roll back to previous deployment config
- docs: update README.md
- chore: update construct ID
- feat: pass hostedzoneid as config
- feat: create stack for webapp in staging
- chore: update hostedZone IDs
- refactor: create hosted zones & certificate as part of a separate stack
- refactor: simplify SpaStack interface
- feat: add policy statements for website deployer role
- ci: deploy
- feat: store certificate ARN and hosted zone ID in ssm
- feat: remove assume role from websitedeployer role
- feat: set distribution id and bucket name in param store
